### PR TITLE
Update AWS CLI install instructions to use pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ As discussed in the previous section, you will find libraries for use in both la
 
 After installation, add 'ulimit -n 65535' to `/etc/default/riak`.
 
-In a Mac environment, you can issue `brew install riak`, which mostly does the right thing. 
+In a Mac environment, you can issue `brew install riak`, which mostly does the right thing.
 
-You will need to issue `ulimit -n 4096` in order for it to stay running. It will probably consume lots of CPU and you may find it is not especially useful to have a Riak on your laptop. Jane has found it is easier to run Riak on a properly sized instance in Amazon, and then run an ssh tunnel out to Amazon. 
+You will need to issue `ulimit -n 4096` in order for it to stay running. It will probably consume lots of CPU and you may find it is not especially useful to have a Riak on your laptop. Jane has found it is easier to run Riak on a properly sized instance in Amazon, and then run an ssh tunnel out to Amazon.
 
 In your `~/.ssh/config` this might look like:
 
@@ -66,7 +66,7 @@ Host infdb
 #### Installation
 
 1. For the moment, simply pulling Sendak down from GitHub with `git clone git@github.com:18F/Sendak.git sendak` will give you everything you need but the prerequisites and AWS credentials.
-2. It is advisable to have the `aws-cli` package from Amazon installed. On a Mac, this is `brew install awscli`. On Ubuntu, you will want `apt-get install awscli`.
+2. It is advisable to have the `aws-cli` package from Amazon installed. You can install this through the Python package manager with `pip install awscli`.
 3. You will need the secret key and the api key from your Amazon account. This is available from the Amazon IAM page. You will need to put this in `~/.aws/config`, as sendak reads its stuff from there (a secret key and access key is available, but difficult to find, in the AWS console).
 4. Your environment will contain various shell variables for configuration's sake; these are defined in `contrib/bash_env.sh`. Each variable is defined with a comment in that file.
 5. Once you have the credentials and environment configured, and your javascript and python packages installed, you should be able to begin using sendak by issuing `sendak --help` and similar. There is a `sendak --list-tasks` command that will show you the available tasks. At present this does not report on their suitability at all and merely indicates their presence in the `bin/` tree.


### PR DESCRIPTION
Updates the install instructions to prefer the `pip install awscli` route. This is what I used, is cross-platform, and is what [Amazon recommends](http://aws.amazon.com/cli/).

Fixes #27.
