### PR TITLE
Initial Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - 0.10
+
+script:
+  - echo "Works great."
+


### PR DESCRIPTION
This adds a Travis-compatible script that will always succeed (it just runs `echo "Works great."`). It does know to install Node 0.10.x in a VM first, even though the script doesn't make use of it.

The `script` command could be changed to run anything meaningful that returns a 0 exit code on success and a 1 on failure. `script` is an array field that can list and run multiple commands that all need to succeed for the build to be considered a success.

Once merged, go to https://travis-ci.org/profile/18F (authorize your GitHub account with Travis if you need to) and click the on/off switch next to the Sendak repo. It should Just Work.
