### PR TITLE
Coalesce sprint

### DIFF
--- a/bin/js/coalesce.js
+++ b/bin/js/coalesce.js
@@ -65,6 +65,13 @@ function name_split ( name ) {
 	}
 
 	var regexen = [ // {{{
+		// JaneArc
+		//
+		[ /^[A-Z][a-z]+[A-Z][a-z]$/, function (n) {
+			var name_parts = n.match( /^([A-Z][a-z]+)([A-Z][a-z]+)/ );
+			return new name_struct( name_parts[0], name_parts[1], n );
+		} ],
+
 		// JMArc
 		//
 		[ /^[A-Z]{3}[a-z]+$/, function (n) { return new name_struct(n.substr(0,2), n.substr(2, n.length), n) } ],
@@ -105,15 +112,20 @@ function name_split ( name ) {
 
 	while (nothing_found && (found == undefined)) {
 		regexen.forEach( function (r) {
-			var re     = r.shift()
-				, parser = r.pop();
+			var re     = r[0]
+				, parser = r[1]
 
 			if (new RegExp( re ).test( name )) {
-				// console.log( name + ' is truthy against ' + re );
 				found = parser( name );
-				nouthing_found = false;
+				nothing_found = false;
 			}
 		} );
+		if (found == undefined) {
+			// Looks like we walked the regexes and we did not find one suitable.
+			//   singletear.swf
+			//
+			found = new Error( 'Software is hard. ' + name + ' could not be parsed. Sorry.' );
+		}
 	}
 	return found;
 }


### PR DESCRIPTION
the stumbling block for this was parsing the names into something that looked like names when there were names with varying capitalisation and so forth. this patch includes regexen that mostly take care of this in a fashion that we can "later plug more regexen in" if we encounter names with different capitalisation.

note that the `excludes` file is not documented, but looks like:
```
fetch:sendak jane$ cat etc/excludes.json 
[
  "catherinedevlin",
  "DataDog",
```
etc. Just throw the 'don't consider these people' accounts in there, one-per-line. (note outstanding issue on [`catherinedevlin`](https://github.com/18F/DevOps/issues/170)).

![peppard_likes_regex](https://cloud.githubusercontent.com/assets/777319/5595439/dfbe36b8-92a4-11e4-8efd-3af0b3bafa97.jpg)

**NOTE ALSO**: It appears that while the structures were generated, `rrm` did not actually save them, so I need to look in to that.